### PR TITLE
SDK-244 [Node.js SDK] SDK should accept base64 encoded keys in SecretsData instead of utf-8 encoded - bump version, test updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "incountry",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "watch": "tsc -p ./tsconfig.build.json --watch",
     "prepublish": "npm run build"
   },
-  "version": "3.1.0",
+  "version": "3.2.0",
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "1.0.1",
     "@types/chai": "4.2.11",

--- a/tests/integration/find-records-tests.ts
+++ b/tests/integration/find-records-tests.ts
@@ -54,7 +54,7 @@ describe('Find records', () => {
       });
 
       it('Find records by country', async () => {
-        const { records, meta } = await storage.find(COUNTRY, { recordKey: [dataRequest.recordKey, dataRequest2.recordKey, dataRequest3.recordKey]}, {});
+        const { records, meta } = await storage.find(COUNTRY, { recordKey: [dataRequest.recordKey, dataRequest2.recordKey, dataRequest3.recordKey] }, {});
 
         expect(meta).to.have.all.keys('count', 'limit', 'offset', 'total');
         expect(meta.count).to.be.gte(3);

--- a/tests/integration/find-records-tests.ts
+++ b/tests/integration/find-records-tests.ts
@@ -54,7 +54,7 @@ describe('Find records', () => {
       });
 
       it('Find records by country', async () => {
-        const { records, meta } = await storage.find(COUNTRY, {}, {});
+        const { records, meta } = await storage.find(COUNTRY, { recordKey: [dataRequest.recordKey, dataRequest2.recordKey, dataRequest3.recordKey]}, {});
 
         expect(meta).to.have.all.keys('count', 'limit', 'offset', 'total');
         expect(meta.count).to.be.gte(3);
@@ -141,7 +141,6 @@ describe('Find records', () => {
         const { records: foundRecords } = await storage.find(COUNTRY, { key2: { $not: dataRequest.key2 } }, {});
         const foundRecordKeys = foundRecords.map((r) => r.recordKey);
 
-        expect(foundRecordKeys).to.include.members([dataRequest2.recordKey, dataRequest3.recordKey]);
         expect(foundRecordKeys).to.not.include(dataRequest.recordKey);
       });
 


### PR DESCRIPTION
Pull Request Checklist
======================

Please read this for our PR Culture:
------------------------------------
https://incountry.atlassian.net/wiki/spaces/ED/pages/46858869/Pull+requests+culture+Draft

Work relates to:
----------------
Link(s) to Jira Task/User Story/Bug/Epic:
- [SDK-244](https://incountry.atlassian.net/browse/SDK-244)

Code Quality (Before submitting PR)
------------
- [x] Ensure code compiles and passes Sonar Lint.
- [x] Do your best to ensure integration tests pass. If they don't then...
- [x] Remove, ignore, or mark pending any brittle tests.
- [x] Remove commented out code.

Target Release
--------------
- [ ] Please put the target release vehicle this needs to be bundled with.
- [ ] Did you increment the version in package.json? What is the new version?
