### PR TITLE
DEVOPS-2982: Remove parameter '-o pipefail' and add the new variable BUILD_AND_SCAN_DOCKER_FOR_ANY_BRANCH

### DIFF
--- a/travis-build.sh
+++ b/travis-build.sh
@@ -5,7 +5,6 @@ if [[ "${TRAVIS_BUILD_SCRIPT_DEBUG_ENABLED:-false}" == 'true' ]]; then
 fi
 
 set -e
-set -o pipefail
 
 RED="\033[31;1m"
 GREEN="\033[32;1m"
@@ -27,7 +26,7 @@ branch_matches() {
 npm install
 
 # SNYK dependency scan - runs for master and RC branches, but not for PRs
-if [[ "$TRAVIS_PULL_REQUEST" == 'false' ]] && branch_matches "^master$|^develop$|^SB_*|^RC_*"; then
+if [[ "$TRAVIS_PULL_REQUEST" == 'false' || "${BUILD_AND_SCAN_DOCKER_FOR_ANY_BRANCH}" == 'true' ]] && branch_matches "^master$|^develop$|^SB_*|^RC_*"; then
   npm install -g snyk
   snyk monitor --org=incountry --prune-repeated-subdependencies --remote-repo-url="${APP_NAME}" --project-name="${APP_NAME}:${TRAVIS_BRANCH}"
 else


### PR DESCRIPTION
Work relates to:
----------------
Link(s) to Jira Task/User Story/Bug/Epic:
- https://incountry.atlassian.net/browse/DEVOPS-2981
- https://incountry.atlassian.net/browse/DEVOPS-2982

### Any additional notes (If applicable)

Adding the new variable BUILD_AND_SCAN_DOCKER_FOR_ANY_BRANCH (default = false). When BUILD_AND_SCAN_DOCKER_FOR_ANY_BRANCH is temporarily set to 'true' in Travis job envvars the job should perform the Docker build and SNYK scan for any branch, not just for RC, SB, and master.
--------------------
Travis build failing on pipefail that was hard to debug. We decided that it is better to remove ‘-o pipefail’  from all our travis-ci pipeline scripts.