### PR TITLE
SDK-331 [Node.js SDK] allow expiresAt to be ISO-8601 strings as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ type StorageRecordData = {
   rangeKey8?: t.Int | null;
   rangeKey9?: t.Int | null;
   rangeKey10?: t.Int | null;
-  expiresAt?: Date | null;
+  expiresAt?: string | Date | null; // Accepts only ISO-8601 formatted strings, like '2021-03-11T17:23:05.941Z'
 };
 
 type WriteResult = {
@@ -506,7 +506,8 @@ const readResult = await storage.read(countryCode, recordKey);
 You can look up for data records either by using exact match search operators or partial text match operator in almost any combinations.
 
 ```typescript
-type FilterDateQuery = Date | Date[] | null | { $not?: Date | Date[] | null; $gt?: Date; $gte?: Date; $lt?: Date; $lte?: Date; };
+type DateOr8601 = string | Date; // Accepts only ISO-8601 formatted strings, like '2021-03-11T17:23:05.941Z'
+type FilterDateQuery = DateOr8601 | DateOr8601[] | null | { $not?: DateOr8601 | DateOr8601[] | null; $gt?: DateOr8601; $gte?: DateOr8601; $lt?: DateOr8601; $lte?: DateOr8601; };
 type FilterStringQuery = string | string[] | null | { $not?: string | string[] | null };
 type FilterNumberQuery = number | number[] | null | { $not?: number | number[] | null; $gt?: number; $gte?: number; $lt?: number; $lte?: number; };
 

--- a/src/validation/api/api-record-data.ts
+++ b/src/validation/api/api-record-data.ts
@@ -90,7 +90,7 @@ function apiRecordDataFromStorageRecordData<A extends StorageRecordData>(recordD
     key19: recordData.key19,
     key20: recordData.key20,
     parent_key: recordData.parentKey,
-    expires_at: recordData.expiresAt ? recordData.expiresAt.toISOString() : recordData.expiresAt,
+    expires_at: recordData.expiresAt && recordData.expiresAt instanceof Date ? recordData.expiresAt.toISOString() : recordData.expiresAt,
   });
 }
 

--- a/src/validation/user-input/find-filter.ts
+++ b/src/validation/user-input/find-filter.ts
@@ -2,7 +2,7 @@ import intersection from 'lodash.intersection';
 import { left, right, Either } from 'fp-ts/lib/Either';
 import * as t from 'io-ts';
 import { exact } from '../exact';
-import { DateIO, chainValidate } from '../utils';
+import { DateIO, DateOr8601, chainValidate } from '../utils';
 
 const SEARCH_FIELD = 'searchKeys';
 const EXCLUDED_KEYS_WHEN_SEARCHING = [
@@ -69,17 +69,17 @@ const FilterNumberQueryIO: t.Type<FilterNumberQuery> = t.union([
 ]);
 
 // filter date value
-type FilterDateValue = Date | Date[] | null;
+type FilterDateValue = DateOr8601 | DateOr8601[] | null;
 const FilterDateValueIO: t.Type<FilterDateValue> = t.union([DateIO, t.array(DateIO), t.null]);
 
 type FilterDateQuery =
 FilterDateValue |
   {
     $not?: FilterDateValue;
-    $gt?: Date;
-    $gte?: Date;
-    $lt?: Date;
-    $lte?: Date;
+    $gt?: DateOr8601;
+    $gte?: DateOr8601;
+    $lt?: DateOr8601;
+    $lte?: DateOr8601;
   };
 
 const FilterDateQueryIO: t.Type<FilterDateQuery> = t.union([

--- a/src/validation/user-input/storage-record-data.ts
+++ b/src/validation/user-input/storage-record-data.ts
@@ -1,5 +1,7 @@
 import * as t from 'io-ts';
-import { Codec, StringMax256, DateIO } from '../utils';
+import {
+  Codec, StringMax256, DateOr8601, DateIO,
+} from '../utils';
 
 type StorageRecordData = {
   recordKey: string;
@@ -42,7 +44,7 @@ type StorageRecordData = {
   rangeKey8?: t.Int | null;
   rangeKey9?: t.Int | null;
   rangeKey10?: t.Int | null;
-  expiresAt?: Date | null;
+  expiresAt?: DateOr8601 | null;
 };
 
 const getStorageRecordDataIO = (params: { hashSearchKeys: boolean }): Codec<StorageRecordData> => {

--- a/src/validation/utils.ts
+++ b/src/validation/utils.ts
@@ -5,6 +5,8 @@ import { pipe } from 'fp-ts/lib/pipeable';
 import {
   isLeft, isRight, Either, fold, either,
 } from 'fp-ts/lib/Either';
+import { DateFromISOString } from 'io-ts-types/lib/DateFromISOString';
+import { date } from 'io-ts-types/lib/date';
 import { getErrorMessage } from './get-error-message';
 import {
   StorageServerError,
@@ -117,9 +119,14 @@ const isReadable = (o: unknown): o is Readable => o instanceof Readable;
 
 const ReadableIO = codecFromValidate(isReadable, 'File');
 
-const isDate = (o: unknown): o is Date => o instanceof Date;
+type DateOr8601 = string | Date;
 
-const DateIO = codecFromValidate(isDate, 'Date');
+const DateIO = new t.Type<DateOr8601>(
+  'DateIO',
+  (u): u is DateOr8601 => u instanceof Date ? date.is(u) : isRight(DateFromISOString.decode(u)),
+  (i, c) => i instanceof Date ? date.validate(i, c) : DateFromISOString.validate(i, c),
+  t.identity,
+);
 
 type Codec<A> = t.Type<A, unknown>;
 type Int = t.Int;
@@ -169,7 +176,7 @@ export {
   PositiveInt,
   NonNegativeInt,
   ReadableIO,
-  isDate,
+  DateOr8601,
   DateIO,
   optional,
   getErrorMessage,

--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -4,6 +4,7 @@
         "@typescript-eslint/ban-ts-comment": "warn",
         "@typescript-eslint/ban-ts-ignore": "warn",
         "@typescript-eslint/explicit-function-return-type": "off",
+        "@typescript-eslint/camelcase": "off",
         "no-unused-expressions": "off",
         "no-console": "off"
     }

--- a/tests/unit/storage/batch-write-tests.ts
+++ b/tests/unit/storage/batch-write-tests.ts
@@ -186,6 +186,21 @@ describe('Storage', () => {
                 expect(r.is_encrypted).to.equal(opt.encrypted);
               });
             });
+
+            it('should parse "expiresAt" as ISO8601', async () => {
+              const storage = opt.encrypted ? encStorage : noEncStorage;
+              const testRecords = TEST_RECORDS.map((record) => ({
+                ...record,
+                expiresAt: record.expiresAt && record.expiresAt instanceof Date ? record.expiresAt.toISOString() : record.expiresAt,
+              }));
+              const [bodyObj] = await Promise.all<any>([getNockedRequestBodyObject(popAPI), storage.batchWrite(COUNTRY, testRecords)]);
+              (bodyObj.records as any[]).forEach((r, index) => {
+                const { expiresAt } = TEST_RECORDS[index];
+                if (r.expires_at && expiresAt) {
+                  expect(r.expires_at).to.equal(expiresAt.toISOString());
+                }
+              });
+            });
           });
         });
       });

--- a/tests/unit/storage/find-tests.ts
+++ b/tests/unit/storage/find-tests.ts
@@ -190,6 +190,24 @@ describe('Storage', () => {
           assert.equal(popAPI.isDone(), true, 'nock is done');
         });
 
+        it('should accept "createdAt", "updatedAt", "expiresAt" as ISO8601', async () => {
+          const filter = {
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            expiresAt: new Date().toISOString(),
+          };
+
+          const popAPI = nockPopApi(POPAPI_HOST).find(COUNTRY)
+            .reply(200, getDefaultFindResponse());
+
+          const [bodyObj] = await Promise.all<any>([getNockedRequestBodyObject(popAPI), encStorage.find(COUNTRY, filter)]);
+          expect(bodyObj.filter).to.deep.equal({
+            created_at: filter.createdAt,
+            updated_at: filter.updatedAt,
+            expires_at: filter.expiresAt,
+          });
+        });
+
         type KEY =
           | 'recordKey'
           | 'key1'

--- a/tests/unit/storage/write-tests.ts
+++ b/tests/unit/storage/write-tests.ts
@@ -149,6 +149,21 @@ describe('Storage', () => {
                   const [bodyObj] = await Promise.all<any, WriteResult>([getNockedRequestBodyObject(popAPI), storage.write(COUNTRY, testCase)]);
                   expect(bodyObj.is_encrypted).to.equal(opt.encrypted);
                 });
+
+                if (testCase.expiresAt && testCase.expiresAt instanceof Date) {
+                  it('should parse "expiresAt" as ISO8601', async () => {
+                    const storage = opt.encrypted ? encStorage : noEncStorage;
+
+                    const data = {
+                      ...testCase,
+                      expiresAt: testCase.expiresAt.toISOString(),
+                    };
+                    const [bodyObj, writeRes] = await Promise.all<any, WriteResult>([getNockedRequestBodyObject(popAPI), storage.write(COUNTRY, data)]);
+                    expect(bodyObj.expires_at).to.equal(testCase.expiresAt.toISOString());
+                    expect(writeRes.record.expiresAt).to.be.a('date');
+                    expect(writeRes.record.expiresAt).to.equalDate(testCase.expiresAt);
+                  });
+                }
               });
             });
           });

--- a/tests/unit/validation/find-filter-test.ts
+++ b/tests/unit/validation/find-filter-test.ts
@@ -38,8 +38,11 @@ const VALID_FIND_FILTER: FindFilter[] = [
   { rangeKey1: null },
   { rangeKey1: { $not: null } },
   { createdAt: new Date() },
+  { createdAt: new Date().toISOString() },
   { updatedAt: new Date() },
+  { updatedAt: new Date().toISOString() },
   { expiresAt: new Date() },
+  { expiresAt: new Date().toISOString() },
   { expiresAt: [new Date()] },
   { expiresAt: { $not: [new Date()] } },
 ];

--- a/tests/unit/validation/storage-data-array-test.ts
+++ b/tests/unit/validation/storage-data-array-test.ts
@@ -24,6 +24,8 @@ const VALID = [
   [KEYS.reduce((acc, key) => Object.assign(acc, { [key]: dummyString5000 }), { recordKey: '1' })],
 
   Array(MAX_RECORDS_IN_BATCH).fill('x').map(() => ({ recordKey: '1' })),
+  [{ recordKey: '1', expiresAt: new Date() }],
+  [{ recordKey: '1', expiresAt: new Date().toISOString() }],
 ];
 
 const INVALID = [
@@ -42,6 +44,7 @@ const INVALID = [
   [{ record_key: 1 }],
   [{ record_key: '', body: 1 }],
   Array(MAX_RECORDS_IN_BATCH + 1).fill('x').map(() => ({ recordKey: '1' })),
+  [{ recordKey: '1', expiresAt: 'test' }],
 ];
 
 const VALID_NOT_HASHED = [


### PR DESCRIPTION
Pull Request Checklist
======================

Please read this for our PR Culture:
------------------------------------
https://incountry.atlassian.net/wiki/spaces/ED/pages/46858869/Pull+requests+culture+Draft

Work relates to:
----------------
Link(s) to Jira Task/User Story/Bug/Epic:
- [SDK-331](https://incountry.atlassian.net/browse/SDK-331)

Code Quality (Before submitting PR)
------------
- [x] Ensure code compiles and passes Sonar Lint.
- [x] Do your best to ensure integration tests pass. If they don't then...
- [x] Remove, ignore, or mark pending any brittle tests.
- [x] Remove commented out code.

Target Release
--------------
- [x] Please put the target release vehicle this needs to be bundled with.
- [x] Did you increment the version in package.json? What is the new version?
