### PR TITLE
DEVOPS-2982: Remove option ‘-o pipefail’

### DIFF
--- a/travis-build.sh
+++ b/travis-build.sh
@@ -5,7 +5,6 @@ if [[ "${TRAVIS_BUILD_SCRIPT_DEBUG_ENABLED:-false}" == 'true' ]]; then
 fi
 
 set -e
-set -o pipefail
 
 RED="\033[31;1m"
 GREEN="\033[32;1m"


### PR DESCRIPTION
Work relates to:
Link(s) to Jira Task/User Story/Bug/Epic:

https://incountry.atlassian.net/browse/DEVOPS-2982
Any additional notes (If applicable)
Travis build failing on pipefail that was hard to debug. We decided that it is better to remove ‘-o pipefail’ from all our travis-ci pipeline scripts.